### PR TITLE
ci: update GitHub Actions and add Node.js version matrix

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,9 +1,9 @@
 name: CI
 on:
   push:
-    branches: [main]
+    branches: [master]
   pull_request:
-    branches: [main]
+    branches: [master]
 
 jobs:
   build:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,6 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-          cache: npm
 
       - name: Install dependencies
         run: npm install

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,22 +5,19 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        node-version: [20, 22, 24]
+
     steps:
       - name: Begin CI...
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
-      - name: Use Node 12
-        uses: actions/setup-node@v1
+      - name: Use Node ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
         with:
-          node-version: 12.x
-
-      - name: Use cached node_modules
-        uses: actions/cache@v1
-        with:
-          path: node_modules
-          key: nodeModules-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            nodeModules-
+          node-version: ${{ matrix.node-version }}
+          cache: npm
 
       - name: Install dependencies
         run: npm install

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,20 +24,12 @@ jobs:
 
       - name: Install dependencies
         run: npm install
-        env:
-          CI: true
 
       - name: Lint
         run: npm run lint
-        env:
-          CI: true
 
       - name: Test
         run: npm test -- --ci --coverage --maxWorkers=2
-        env:
-          CI: true
 
       - name: Build
         run: npm run build
-        env:
-          CI: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,9 @@
 name: CI
-on: [push]
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
 
 jobs:
   build:


### PR DESCRIPTION
Bump actions/checkout to v4 and actions/setup-node to v4, drop the
separate actions/cache step in favor of setup-node's built-in npm cache,
and run the build against Node.js 20, 22, and 24.