### PR TITLE
Update CI workflow actions and run on Node 20/22/24

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,14 +18,6 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
 
-      - name: Use cached node_modules
-        uses: actions/cache@v4
-        with:
-          path: node_modules
-          key: nodeModules-${{ matrix.node-version }}-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            nodeModules-${{ matrix.node-version }}-
-
       - name: Install dependencies
         run: npm install
         env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,9 @@
 name: CI
-on: [push]
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
 
 jobs:
   build:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,20 +24,12 @@ jobs:
 
       - name: Install dependencies
         run: npm install
-        env:
-          CI: true
 
       - name: Lint
         run: npm run lint
-        env:
-          CI: true
 
       - name: Test
         run: npm test -- --ci --coverage --maxWorkers=2
-        env:
-          CI: true
 
       - name: Build
         run: npm run build
-        env:
-          CI: true

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,22 +5,26 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        node-version: [20, 22, 24]
+
     steps:
       - name: Begin CI...
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
-      - name: Use Node 12
-        uses: actions/setup-node@v1
+      - name: Use Node ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
         with:
-          node-version: 12.x
+          node-version: ${{ matrix.node-version }}
 
       - name: Use cached node_modules
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: node_modules
-          key: nodeModules-${{ hashFiles('**/package-lock.json') }}
+          key: nodeModules-${{ matrix.node-version }}-${{ hashFiles('**/package-lock.json') }}
           restore-keys: |
-            nodeModules-
+            nodeModules-${{ matrix.node-version }}-
 
       - name: Install dependencies
         run: npm install


### PR DESCRIPTION
Bump actions/checkout, actions/setup-node, and actions/cache to v4, and
replace the single Node 12 job with a matrix over Node 20, 22, and 24.
The cache key now includes the matrix Node version so each version gets
its own cache slice.